### PR TITLE
Fix docs build and run it on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -31,9 +32,8 @@ jobs:
       - name: Install package and doc dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install maturin
           pip install -r docs/requirements.txt
-          maturin develop --release --manifest-path file_re/Cargo.toml
+          pip install ./file_re
 
       - name: Build Sphinx site
         run: |
@@ -41,13 +41,16 @@ jobs:
           make html
 
       - uses: actions/configure-pages@v5
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
 
       - uses: actions/upload-pages-artifact@v3
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
         with:
           path: docs/_build/html
 
   deploy:
     needs: build
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     environment:
       name: github-pages

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,25 +2,14 @@
 
 from __future__ import annotations
 
-import sys
 from datetime import date
 from importlib import metadata
-from pathlib import Path
-
-_PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "file_re" / "python"
-if str(_PACKAGE_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PACKAGE_ROOT))
-
-import file_re  # noqa: E402
 
 project = "file_re"
 author = "file_re contributors"
 copyright = f"{date.today().year}, {author}"
 
-try:
-    release = metadata.version("file_re")
-except metadata.PackageNotFoundError:
-    release = file_re.__version__
+release = metadata.version("file_re")
 version = ".".join(release.split(".")[:2])
 
 extensions = [


### PR DESCRIPTION
- Swap `maturin develop` for `pip install ./file_re` so the docs workflow works without an activated venv (this is why the first main-branch run failed right after merging #9).
- Make the `build` job also run on `pull_request`, so broken docs are caught before merge. The `deploy` step still only runs on `main` push and `workflow_dispatch`.