### PR TITLE
Switch docs to sphinx_rtd_theme, bump to 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # file_re
 
-[![Documentation Status](https://readthedocs.org/projects/file-re/badge/?version=latest)](https://file-re.readthedocs.io/en/latest/)
 [![PyPI version](https://img.shields.io/pypi/v/file_re.svg)](https://pypi.org/project/file_re/)
 
 `file_re` is a Rust-backed Python library for running regular expressions
@@ -9,7 +8,7 @@ and adds a single `max_span_lines` parameter that controls how much of
 the file is held in memory — the same API scales from small
 configuration files to 50 GB compressed logs.
 
-- **Docs:** <https://file-re.readthedocs.io>
+- **Docs:** <https://janet16180.github.io/file_re/>
 - **PyPI:** <https://pypi.org/project/file_re/>
 - **Source:** this repository
 
@@ -78,7 +77,7 @@ match = file_re.search(
 ```
 
 `re.ASCII`, `re.DEBUG`, and `re.LOCALE` have Rust-specific semantics;
-see the [flags guide](https://file-re.readthedocs.io/en/latest/guides/flags.html).
+see the [flags guide](https://janet16180.github.io/file_re/guides/flags.html).
 
 ### Compiled patterns
 
@@ -130,7 +129,7 @@ if __name__ == "__main__":
         print(sum(pool.map(count_matches, shards)))
 ```
 
-See the [large files guide](https://file-re.readthedocs.io/en/latest/guides/large_files.html)
+See the [large files guide](https://janet16180.github.io/file_re/guides/large_files.html)
 for details.
 
 ## Migrating from 1.x
@@ -139,7 +138,7 @@ for details.
 `max_span_lines`, `Match.groups` now reports `None` (not `""`) for
 non-participating groups, and `search()` in window mode returns the
 first match. The full migration guide is at
-<https://file-re.readthedocs.io/en/latest/guides/migration_1_to_2.html>.
+<https://janet16180.github.io/file_re/guides/migration_1_to_2.html>.
 
 ## Development
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,11 +57,17 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
 }
 
-html_theme = "furo"
+html_theme = "sphinx_rtd_theme"
 html_title = f"file_re {release}"
 html_static_path: list[str] = []
 
+html_theme_options = {
+    "navigation_depth": 3,
+    "collapse_navigation": False,
+    "sticky_navigation": True,
+    "style_external_links": True,
+}
+
 pygments_style = "sphinx"
-pygments_dark_style = "monokai"
 
 nitpicky = False

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=8.1,<9
-furo>=2024.8.6
+sphinx-rtd-theme>=3.0,<4
 sphinx-autodoc-typehints>=2.5,<4
 myst-parser>=4.0,<5

--- a/file_re/Cargo.lock
+++ b/file_re/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "file_re"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "flate2",
  "pyo3",

--- a/file_re/Cargo.toml
+++ b/file_re/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_re"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/file_re/README.md
+++ b/file_re/README.md
@@ -6,7 +6,7 @@ and adds a single `max_span_lines` parameter that controls how much of
 the file is held in memory — the same API scales from small configuration
 files to 50 GB compressed logs.
 
-- **Documentation:** <https://file-re.readthedocs.io>
+- **Documentation:** <https://janet16180.github.io/file_re/>
 - **Source:** <https://github.com/Janet16180/file_re>
 
 ## Install
@@ -50,7 +50,7 @@ for m in file_re.finditer(r"\bERROR\b", "huge.log", max_span_lines=1):
   `re.VERBOSE`, `re.UNICODE`, and `re.ASCII` (with Rust-specific
   divergence notes in the docs)
 
-See the full [documentation](https://file-re.readthedocs.io) for the
+See the full [documentation](https://janet16180.github.io/file_re/) for the
 large-file guide, flag parity details, and the 1.x to 2.0 migration
 guide.
 

--- a/file_re/python/file_re/__init__.py
+++ b/file_re/python/file_re/__init__.py
@@ -2,7 +2,7 @@ from .core import file_re_cls
 from .match import Match
 from .pattern import Pattern
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 file_re = file_re_cls
 search = file_re_cls.search


### PR DESCRIPTION
- Swap the Sphinx theme from furo to sphinx_rtd_theme (classic Read the Docs look).
- Bump version to 2.0.1

