### PR TITLE
Switch release to pypa/gh-action-pypi-publish with Trusted Publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -237,24 +237,26 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [linux, musllinux, windows, macos, sdist]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/file_re
     permissions:
-      # Use to sign the release artifacts
       id-token: write
-      # Used to upload release artifacts
-      contents: write
-      # Used to generate artifact attestation
       attestations: write
     steps:
       - uses: actions/download-artifact@v4
-      - name: Generate artifact attestation
+      - name: Collect wheels into dist/
+        run: |
+          mkdir -p dist
+          mv wheels-*/* dist/
+      - name: Generate SLSA build provenance
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: 'dist/*'
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --non-interactive --skip-existing wheels-*/*
+          packages-dir: dist
+          skip-existing: true
+          attestations: true


### PR DESCRIPTION
Addresses PyO3/maturin#2334 (maturin upload is being deprecated and does not emit PEP 740 attestations). First commit swaps the publish step to pypa/gh-action-pypi-publish with PyPI Trusted Publishing over OIDC, so there is no PYPI_API_TOKEN to rotate and attestations are emitted automatically. Second commit is temporary and should be dropped before merge, it runs the release job on this PR too and points at TestPyPI so the flow is exercised end to end before we tag.

One time setup needed on PyPI side: add a trusted publisher for owner Janet16180, repo file_re, workflow CI.yml, environment pypi. Same on TestPyPI with environment testpypi so this PR can actually upload a test wheel.